### PR TITLE
Show login user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,10 @@ storybook-static
 .pnp.*
 
 packages/*/dist
+.npmrc
 
+.idea
+.idea/misc.xml
 .idea/workspace.xml
 .idea/tasks.xml
-.npmrc
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "repository": "https://github.com/UW-Macrostrat/web-components.git",
-  "version": "4.2.1",
+  "version": "4.2.0",
   "scripts": {
     "dev": "NODE_NO_WARNINGS=1 storybook dev -p 6006 --no-open",
     "build:storybook": "storybook build --debug",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "repository": "https://github.com/UW-Macrostrat/web-components.git",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "scripts": {
     "dev": "NODE_NO_WARNINGS=1 storybook dev -p 6006 --no-open",
     "build:storybook": "storybook build --debug",

--- a/packages/form-components/CHANGELOG.md
+++ b/packages/form-components/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.10
+
+### Patch Changes
+
+- Show the signed-in user's name on the `AuthStatus` login button, falling back
+  to the email, then "Logged in". The label is derived by a new
+  `userDisplayName` prop that defaults to the built-in `defaultUserDisplayName`
+  (also exported), so consumers can customize it.
+
 ## [1.0.9] - 2026-05-20 [_changes_](https://github.com/UW-Macrostrat/web-components/compare/@macrostrat/form-components-v1.0.8...@macrostrat/form-components-v1.0.9)
 
 ### Patch Changes

--- a/packages/form-components/package.json
+++ b/packages/form-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macrostrat/form-components",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Form components for user input into Macrostrat apps",
   "repository": {
     "type": "git",

--- a/packages/form-components/src/auth/index.ts
+++ b/packages/form-components/src/auth/index.ts
@@ -5,10 +5,7 @@ import { useAuth } from "./context";
 import styles from "./main.module.sass";
 const h = hyperStyled(styles);
 
-/* Display user's name in the login button field.
-  It'll render the user from `/security/me` and fall back to 'Logged in' when no
-  name is available. */
-function userDisplayName(user: unknown): string {
+function defaultUserDisplayName(user: unknown): string {
   if (typeof user === "string") return user;
   if (user != null && typeof user === "object") {
     const u = user as Record<string, unknown>;
@@ -20,7 +17,12 @@ function userDisplayName(user: unknown): string {
 
 function AuthStatus(props) {
   const { runAction, user } = useAuth();
-  let { className, large = true, showText = true } = props;
+  let {
+    className,
+    large = true,
+    showText = true,
+    userDisplayName = defaultUserDisplayName,
+  } = props;
 
   let text = "Not logged in";
   let icon: IconName = "blocked-person";
@@ -45,7 +47,7 @@ function AuthStatus(props) {
   ]);
 }
 
-export { AuthStatus };
+export { AuthStatus, defaultUserDisplayName };
 export * from "./login-form";
 export * from "./util";
 export * from "./context";

--- a/packages/form-components/src/auth/index.ts
+++ b/packages/form-components/src/auth/index.ts
@@ -5,6 +5,19 @@ import { useAuth } from "./context";
 import styles from "./main.module.sass";
 const h = hyperStyled(styles);
 
+/* Display user's name in the login button field.
+  It'll render the user from `/security/me` and fall back to 'Logged in' when no
+  name is available. */
+function userDisplayName(user: unknown): string {
+  if (typeof user === "string") return user;
+  if (user != null && typeof user === "object") {
+    const u = user as Record<string, unknown>;
+    const label = u.name ?? u.username ?? u.email;
+    if (typeof label === "string" && label.length > 0) return label;
+  }
+  return "Logged in";
+}
+
 function AuthStatus(props) {
   const { runAction, user } = useAuth();
   let { className, large = true, showText = true } = props;
@@ -13,7 +26,7 @@ function AuthStatus(props) {
   let icon: IconName = "blocked-person";
   let action: () => void = () => runAction({ type: "login" });
   if (user != null) {
-    text = "Logged in";
+    text = userDisplayName(user);
     icon = "person";
     action = () => runAction({ type: "request-form" });
   }

--- a/packages/form-components/stories/auth-status.stories.ts
+++ b/packages/form-components/stories/auth-status.stories.ts
@@ -9,8 +9,6 @@ import { Meta } from "@storybook/react-vite";
 const noopTransformer = async () => null;
 
 function AuthStatusFor({ user }: { user: unknown }) {
-  // BaseAuthProvider only reads `user` as its initial reducer state, so keying
-  // by the user forces a remount when the controls change.
   return h(
     BaseAuthProvider,
     { key: JSON.stringify(user) ?? "null", user, transformer: noopTransformer },

--- a/packages/form-components/stories/auth-status.stories.ts
+++ b/packages/form-components/stories/auth-status.stories.ts
@@ -1,0 +1,48 @@
+import h from "@macrostrat/hyper";
+import { AuthStatus, BaseAuthProvider } from "../src";
+import { Meta } from "@storybook/react-vite";
+
+/* The `AuthStatus` button shows the signed-in user's name, falling back to the
+  email, then "Logged in", and "Not logged in" when there is no user.
+ */
+
+const noopTransformer = async () => null;
+
+function AuthStatusFor({ user }: { user: unknown }) {
+  // BaseAuthProvider only reads `user` as its initial reducer state, so keying
+  // by the user forces a remount when the controls change.
+  return h(
+    BaseAuthProvider,
+    { key: JSON.stringify(user) ?? "null", user, transformer: noopTransformer },
+    h(AuthStatus),
+  );
+}
+
+function Case({ label, user }: { label: string; user: unknown }) {
+  return h("div.auth-status-case", { style: { marginBottom: "1.5rem" } }, [
+    h("div", { style: { fontSize: "0.8rem", opacity: 0.6 } }, label),
+    h(AuthStatusFor, { user }),
+  ]);
+}
+
+export default {
+  title: "Form components/Auth status",
+  component: AuthStatus,
+  args: { name: "Jane Doe", email: "jane@example.com" },
+  argTypes: {
+    name: { control: "text" },
+    email: { control: "text" },
+  },
+} as Meta<typeof AuthStatus>;
+
+/* Each display case, driven by the shared `name` `email` controls. */
+export function Test({ name, email }: { name: string; email: string }) {
+  const withName = { name: name || undefined, email: email || undefined, sub: "auth0|example" };
+  const emailOnly = { email: email || undefined, sub: "auth0|example" };
+  return h("div", [
+    h(Case, { label: "Name present → shows the name", user: withName }),
+    h(Case, { label: "Name blank, email present → falls back to the email", user: emailOnly }),
+    h(Case, { label: "Neither → falls back to \"Logged in\"", user: { sub: "auth0|example" } }),
+    h(Case, { label: "No user → \"Not logged in\"", user: null }),
+  ]);
+}


### PR DESCRIPTION
## Show the signed-in user's name on the login button

Previously the login button always said "Logged in" for everyone. Now it
shows the signed-in person's name so you can tell what account you're using.

- Falls back when to the email address if there is no name and 'Logged in' if neither are provided. It fails to login if there is no valid user and will remain as 'Logged out'
